### PR TITLE
Add quotation mark and escaping support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added support for `quote_char` and `escape_char` arguments to have optional quotation and
+  escaping support.
+
 ## [0.1.0] - 2024-05-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,14 @@ version = 3
 
 [[package]]
 name = "demo"
-version = "0.1.0"
+version = "0.2.0-unstable"
 dependencies = [
  "merge-whitespace",
 ]
 
 [[package]]
 name = "merge-whitespace"
-version = "0.1.0"
+version = "0.2.0-unstable"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # merge_whitespace
 
+[![Crates.io](https://img.shields.io/crates/v/merge-whitespace)](https://crates.io/crates/merge-whitespace)
+[![Crates.io](https://img.shields.io/crates/l/merge-whitespace)](https://crates.io/crates/merge-whitespace)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/sunsided/merge-whitespace-rs/rust.yml)
+[![docs.rs](https://img.shields.io/docsrs/merge-whitespace)](https://docs.rs/merge-whitespace/)
 [![codecov](https://codecov.io/gh/sunsided/merge-whitespace-rs/graph/badge.svg?token=U6viefmywe)](https://codecov.io/gh/sunsided/merge-whitespace-rs)
+
 
 This crate contains procedural macros for removing multiple consecutive whitespaces from a
 given string literal, replacing them with a single space.

--- a/README.md
+++ b/README.md
@@ -7,24 +7,31 @@ given string literal, replacing them with a single space.
 
 ## Example
 
+The example below uses an optional quotation characters to keep quoted text ranges un-merged, as well as
+an optional escape character to ensure that quotation character literals are kept as-is.
+
 ```rust
 use merge_whitespace::merge_whitespace;
 
 const QUERY: &str = merge_whitespace!(r#"
-                query {
-                  users (limit: 1) {
-                    id
-                    name
-                    todos(order_by: {created_at: desc}, limit: 5) {
-                      id
-                      title
-                    }
-                  }
-                }
-                "#);
+     query {
+       users (limit: 1, filter: "bought a 12\" vinyl
+                                 named \"spaces  in  space \"") {
+         id
+         name
+         todos(order_by: {created_at: desc}, limit: 5) {
+           id
+           title
+         }
+       }
+     }
+     "#,
+     quote_char = '"',
+     escape_char = '\\');
 
 #[test]
 fn test() {
-    assert_eq!(QUERY, "query { users (limit: 1) { id name todos(order_by: {created_at: desc}, limit: 5) { id title } } }");
+    assert_eq!(QUERY, r#"query { users (limit: 1, filter: "bought a 12\" vinyl
+                                 named \"spaces  in  space \"") { id name todos(order_by: {created_at: desc}, limit: 5) { id title } } }"#);
 }
 ```

--- a/bins/demo/Cargo.toml
+++ b/bins/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demo"
-version = "0.1.0"
+version = "0.2.0-unstable"
 edition = "2021"
 
 [dependencies]

--- a/bins/demo/src/lib.rs
+++ b/bins/demo/src/lib.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use merge_whitespace::merge_whitespace;
+    use merge_whitespace::*;
 
     const OUTPUT: &str = merge_whitespace!("This   is   an\r\n  example  \t string.");
 
@@ -26,5 +26,23 @@ mod tests {
                 "#
         );
         assert_eq!(QUERY, "query { users (limit: 1) { id name todos(order_by: {created_at: desc}, limit: 5) { id title } } }");
+    }
+
+    #[test]
+    fn test_quoted() {
+        let output = merge_whitespace_quoted!("Hello     World!\r\n      \"How        are\"         you?");
+        assert_eq!(output, r#"Hello World! "How        are" you?"#);
+
+        let output = merge_whitespace_quoted!("\"Nothing to  see   here    \"");
+        assert_eq!(output, r#""Nothing to  see   here    ""#);
+
+        let output = merge_whitespace_quoted!(" \"Nothing to  see   here    \" ");
+        assert_eq!(output, r#""Nothing to  see   here    ""#);
+
+        let output = merge_whitespace_quoted!("Test:\"Nothing to  see   here    \" ");
+        assert_eq!(output, r#"Test:"Nothing to  see   here    ""#);
+
+        let output = merge_whitespace_quoted!("Test: \"Nothing to  see   here    \" ");
+        assert_eq!(output, r#"Test: "Nothing to  see   here    ""#);
     }
 }

--- a/bins/demo/src/lib.rs
+++ b/bins/demo/src/lib.rs
@@ -46,4 +46,29 @@ mod tests {
         let output = merge_whitespace_quoted!("Test: \"Nothing to  see   here    \" ");
         assert_eq!(output, r#"Test: "Nothing to  see   here    ""#);
     }
+
+    #[test]
+    fn test_quoted_explicit() {
+        let output =
+            merge_whitespace_quoted!("Hello     World!\r\n      \"How        are\"         you?", '"');
+        assert_eq!(output, r#"Hello World! "How        are" you?"#);
+    }
+
+    #[test]
+    fn test_quoted_custom() {
+        let output =
+            merge_whitespace_quoted!("Hello     World!\r\n      'How        are'         you?", '\'');
+        assert_eq!(output, "Hello World! 'How        are' you?");
+    }
+
+    #[test]
+    fn test_quoted_implicit() {
+        let output =
+            merge_whitespace_quoted!("Hello     World!\r\n      \"How        are\"         you?");
+        assert_eq!(output, r#"Hello World! "How        are" you?"#);
+
+        let output =
+            merge_whitespace_quoted!("Hello     World!\r\n      'How        are'         you?");
+        assert_eq!(output, "Hello World! 'How are' you?");
+    }
 }

--- a/bins/demo/src/lib.rs
+++ b/bins/demo/src/lib.rs
@@ -30,7 +30,8 @@ mod tests {
 
     #[test]
     fn test_quoted() {
-        let output = merge_whitespace_quoted!("Hello     World!\r\n      \"How        are\"         you?");
+        let output =
+            merge_whitespace_quoted!("Hello     World!\r\n      \"How        are\"         you?");
         assert_eq!(output, r#"Hello World! "How        are" you?"#);
 
         let output = merge_whitespace_quoted!("\"Nothing to  see   here    \"");

--- a/bins/demo/src/lib.rs
+++ b/bins/demo/src/lib.rs
@@ -30,8 +30,10 @@ mod tests {
 
     #[test]
     fn test_quoted() {
-        let output =
-            merge_whitespace!("Hello     World!\r\n      \"How        are\"         you?", '"');
+        let output = merge_whitespace!(
+            "Hello     World!\r\n      \"How        are\"         you?",
+            '"'
+        );
         assert_eq!(output, r#"Hello World! "How        are" you?"#);
 
         let output = merge_whitespace!("\"Nothing to  see   here    \"", '"');
@@ -46,19 +48,16 @@ mod tests {
         let output = merge_whitespace!("Test: \"Nothing to  see   here    \" ", '"');
         assert_eq!(output, r#"Test: "Nothing to  see   here    ""#);
 
-        let output =
-            merge_whitespace!("Hello     World!\r\n      'How        are'         you?");
+        let output = merge_whitespace!("Hello     World!\r\n      'How        are'         you?");
         assert_eq!(output, "Hello World! 'How are' you?");
     }
 
     #[test]
     fn test_unquoted() {
-        let output =
-            merge_whitespace!("Hello     World!\r\n      \"How        are\"         you?");
+        let output = merge_whitespace!("Hello     World!\r\n      \"How        are\"         you?");
         assert_eq!(output, r#"Hello World! "How are" you?"#);
 
-        let output =
-            merge_whitespace!("Hello     World!\r\n      'How        are'         you?");
+        let output = merge_whitespace!("Hello     World!\r\n      'How        are'         you?");
         assert_eq!(output, "Hello World! 'How are' you?");
     }
 }

--- a/bins/demo/src/lib.rs
+++ b/bins/demo/src/lib.rs
@@ -31,44 +31,34 @@ mod tests {
     #[test]
     fn test_quoted() {
         let output =
-            merge_whitespace_quoted!("Hello     World!\r\n      \"How        are\"         you?");
+            merge_whitespace!("Hello     World!\r\n      \"How        are\"         you?", '"');
         assert_eq!(output, r#"Hello World! "How        are" you?"#);
 
-        let output = merge_whitespace_quoted!("\"Nothing to  see   here    \"");
+        let output = merge_whitespace!("\"Nothing to  see   here    \"", '"');
         assert_eq!(output, r#""Nothing to  see   here    ""#);
 
-        let output = merge_whitespace_quoted!(" \"Nothing to  see   here    \" ");
+        let output = merge_whitespace!(" \"Nothing to  see   here    \" ", '"');
         assert_eq!(output, r#""Nothing to  see   here    ""#);
 
-        let output = merge_whitespace_quoted!("Test:\"Nothing to  see   here    \" ");
+        let output = merge_whitespace!("Test:\"Nothing to  see   here    \" ", '"');
         assert_eq!(output, r#"Test:"Nothing to  see   here    ""#);
 
-        let output = merge_whitespace_quoted!("Test: \"Nothing to  see   here    \" ");
+        let output = merge_whitespace!("Test: \"Nothing to  see   here    \" ", '"');
         assert_eq!(output, r#"Test: "Nothing to  see   here    ""#);
+
+        let output =
+            merge_whitespace!("Hello     World!\r\n      'How        are'         you?");
+        assert_eq!(output, "Hello World! 'How are' you?");
     }
 
     #[test]
-    fn test_quoted_explicit() {
+    fn test_unquoted() {
         let output =
-            merge_whitespace_quoted!("Hello     World!\r\n      \"How        are\"         you?", '"');
-        assert_eq!(output, r#"Hello World! "How        are" you?"#);
-    }
-
-    #[test]
-    fn test_quoted_custom() {
-        let output =
-            merge_whitespace_quoted!("Hello     World!\r\n      'How        are'         you?", '\'');
-        assert_eq!(output, "Hello World! 'How        are' you?");
-    }
-
-    #[test]
-    fn test_quoted_implicit() {
-        let output =
-            merge_whitespace_quoted!("Hello     World!\r\n      \"How        are\"         you?");
-        assert_eq!(output, r#"Hello World! "How        are" you?"#);
+            merge_whitespace!("Hello     World!\r\n      \"How        are\"         you?");
+        assert_eq!(output, r#"Hello World! "How are" you?"#);
 
         let output =
-            merge_whitespace_quoted!("Hello     World!\r\n      'How        are'         you?");
+            merge_whitespace!("Hello     World!\r\n      'How        are'         you?");
         assert_eq!(output, "Hello World! 'How are' you?");
     }
 }

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -25,8 +25,11 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, LitStr, Token, Expr};
-use syn::parse::{Parse, ParseStream};
+use syn::{LitStr, parse_macro_input};
+
+use crate::macro_input::MacroInput;
+
+mod macro_input;
 
 /// This is a procedural macro that removes multiple consecutive whitespaces from a given string
 /// literal and replaces them with a single space.
@@ -100,33 +103,6 @@ pub fn merge_whitespace_quoted(input: TokenStream) -> TokenStream {
     };
 
     output.into()
-}
-
-struct MacroInput {
-    string: LitStr,
-    quote_char: Option<char>,
-}
-
-impl Parse for MacroInput {
-    fn parse(input: ParseStream) -> syn::parse::Result<Self> {
-        let string = input.parse()?;
-        let quote_char = if input.is_empty() {
-            None
-        } else {
-            input.parse::<Token![,]>()?;
-            let expr: Expr = input.parse()?;
-            if let Expr::Lit(expr_lit) = expr {
-                if let syn::Lit::Char(lit_char) = expr_lit.lit {
-                    Some(lit_char.value())
-                } else {
-                    return Err(input.error("Expected a char literal"));
-                }
-            } else {
-                return Err(input.error("Expected a char literal"));
-            }
-        };
-        Ok(MacroInput { string, quote_char })
-    }
 }
 
 

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -27,6 +27,7 @@
 //!                                             named \"spaces  in  space \"") { id name todos(order_by: {created_at: desc}, limit: 5) { id title } } }"#);
 //! ```
 
+#[forbid(unsafe_code)]
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -171,6 +171,14 @@ mod tests {
     }
 
     #[test]
+    fn escape_a_space() {
+        assert_eq!(
+            merge_whitespace_with_quotes("what   \\   if I quote\\ spaces", QUOTE, ESCAPE),
+            "what \\  if I quote\\ spaces"
+        );
+    }
+
+    #[test]
     fn quoted_whitespace_with_escaped_quotes() {
         assert_eq!(
             merge_whitespace_with_quotes(

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -33,7 +33,7 @@ use syn::{parse_macro_input, LitStr};
 /// ## Example
 ///
 /// ```
-/// # use merge_whitespace::merge_whitespace;///
+/// # use merge_whitespace::merge_whitespace;
 /// let output = merge_whitespace!("Hello     World!\r\n      How        are         you?");
 /// assert_eq!(output, "Hello World! How are you?");
 /// ```
@@ -50,7 +50,7 @@ pub fn merge_whitespace(input: TokenStream) -> TokenStream {
     let input_str = input.value();
 
     // Replace multiple whitespaces with a single space
-    let output_str = input_str.split_whitespace().collect::<Vec<_>>().join(" ");
+    let output_str = merge_whitespace_segment(&input_str);
 
     // Generate the output tokens
     let output = quote! {
@@ -58,4 +58,100 @@ pub fn merge_whitespace(input: TokenStream) -> TokenStream {
     };
 
     output.into()
+}
+
+/// This is a procedural macro that removes multiple consecutive whitespaces from a given string
+/// literal and replaces them with a single space. Quoted text will be ignored and kept as-is.
+///
+/// ## Example
+///
+/// ```
+/// # use merge_whitespace::merge_whitespace_quoted;
+/// let output = merge_whitespace_quoted!("Hello     World!\r\n      \"How        are\"         you?");
+/// assert_eq!(output, r#"Hello World! "How        are" you?"#);
+/// ```
+///
+/// # Return
+///
+/// The macro expands to the modified string literal.
+#[proc_macro]
+pub fn merge_whitespace_quoted(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let input = parse_macro_input!(input as LitStr);
+
+    // Get the string literal value
+    let input_str = input.value();
+
+    // Replace multiple whitespaces with a single space, skipping quoted blocks
+    let output_str = merge_whitespace_with_quotes(&input_str);
+
+    // Generate the output tokens
+    let output = quote! {
+        #output_str
+    };
+
+    output.into()
+}
+
+fn merge_whitespace_with_quotes(input: &str) -> String {
+    let input = input.trim();
+    let mut result = String::with_capacity(input.len());
+    let mut in_quotes = false;
+    let mut prev_char_was_space = false;
+
+    for c in input.chars() {
+        if c.is_whitespace() && !in_quotes {
+            prev_char_was_space = true;
+            continue;
+        }
+
+        if c == '"' {
+            in_quotes = !in_quotes;
+        }
+
+        if prev_char_was_space {
+            result.push(' ');
+        }
+
+        prev_char_was_space = false;
+        result.push(c);
+    }
+
+    result
+}
+
+fn merge_whitespace_segment(segment: &str) -> String {
+    segment.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn whitespace_only_is_trimmed() {
+        assert_eq!(merge_whitespace_with_quotes("  "), "");
+        assert_eq!(merge_whitespace_with_quotes("  \n \t  "), "");
+    }
+
+    #[test]
+    fn non_whitespace_is_ignored() {
+        assert_eq!(merge_whitespace_with_quotes("abcdefgh.ihkl-"), "abcdefgh.ihkl-");
+    }
+
+    #[test]
+    fn single_whitespace_in_text_is_kept() {
+        assert_eq!(merge_whitespace_with_quotes("foo bar baz"), "foo bar baz");
+    }
+
+    #[test]
+    fn multiple_whitespace_in_text_is_merged() {
+        assert_eq!(merge_whitespace_with_quotes("foo  bar\nbaz"), "foo bar baz");
+    }
+
+    #[test]
+    fn quoted_whitespace_in_text_is_kept() {
+        assert_eq!(merge_whitespace_with_quotes("foo   foobar   \"  bar\n\" baz"), "foo foobar \"  bar\n\" baz");
+    }
 }

--- a/crates/macro/src/macro_input.rs
+++ b/crates/macro/src/macro_input.rs
@@ -1,0 +1,134 @@
+use syn::{Expr, Ident, LitStr, Token};
+use syn::parse::{Parse, ParseStream, Result};
+
+/// Input for the whitespace merging macro.
+pub struct MacroInput {
+    /// The input string to merge whitespaces in.
+    pub string: LitStr,
+    /// The optional quote character to use.
+    pub quote_char: Option<char>,
+    /// The optional escape character to use.
+    pub escape_char: Option<char>,
+}
+
+impl Parse for MacroInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let string = input.parse()?;
+        let mut quote_char = None;
+        let mut escape_char = None;
+
+        while !input.is_empty() {
+            input.parse::<Token![,]>()?;
+
+            if input.peek(Ident) {
+                let ident: Ident = input.parse()?;
+                match &*ident.to_string() {
+                    "quote_char" => {
+                        input.parse::<Token![=]>()?;
+                        let expr: Expr = input.parse()?;
+                        if let Expr::Lit(expr_lit) = expr {
+                            if let syn::Lit::Char(lit_char) = expr_lit.lit {
+                                quote_char = Some(lit_char.value());
+                            } else {
+                                return Err(input.error("Expected a char literal for quote_char"));
+                            }
+                        } else {
+                            return Err(input.error("Expected a char literal for quote_char"));
+                        }
+                    }
+                    "escape_char" => {
+                        input.parse::<Token![=]>()?;
+                        let expr: Expr = input.parse()?;
+                        if let Expr::Lit(expr_lit) = expr {
+                            if let syn::Lit::Char(lit_char) = expr_lit.lit {
+                                escape_char = Some(lit_char.value());
+                            } else {
+                                return Err(input.error("Expected a char literal for escape_char"));
+                            }
+                        } else {
+                            return Err(input.error("Expected a char literal for escape_char"));
+                        }
+                    }
+                    _ => return Err(input.error("Expected 'quote_char' or 'escape_char' identifier")),
+                }
+            } else {
+                let expr: Expr = input.parse()?;
+                if let Expr::Lit(expr_lit) = expr {
+                    if quote_char.is_none() {
+                        if let syn::Lit::Char(lit_char) = expr_lit.lit {
+                            quote_char = Some(lit_char.value());
+                        } else {
+                            return Err(input.error("Expected a char literal for quote_char"));
+                        }
+                    } else if escape_char.is_none() {
+                        if let syn::Lit::Char(lit_char) = expr_lit.lit {
+                            escape_char = Some(lit_char.value());
+                        } else {
+                            return Err(input.error("Expected a char literal for escape_char"));
+                        }
+                    } else {
+                        return Err(input.error("Unexpected additional positional argument"));
+                    }
+                } else {
+                    return Err(input.error("Expected a char literal for positional argument"));
+                }
+            }
+        }
+
+        Ok(MacroInput { string, quote_char, escape_char })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::parse_str;
+    use super::*;
+
+    #[test]
+    fn test_positional_quote_char() {
+        let input: MacroInput = parse_str(r#""Test string", '"' "#).unwrap();
+        assert_eq!(input.string.value(), "Test string");
+        assert_eq!(input.quote_char, Some('"'));
+        assert_eq!(input.escape_char, None);
+    }
+
+    #[test]
+    fn test_named_quote_char() {
+        let input: MacroInput = parse_str(r#""Test string", quote_char = '"'"#).unwrap();
+        assert_eq!(input.string.value(), "Test string");
+        assert_eq!(input.quote_char, Some('"'));
+        assert_eq!(input.escape_char, None);
+    }
+
+    #[test]
+    fn test_positional_quote_and_escape_char() {
+        let input: MacroInput = parse_str(r#""Test string", '"', '\\'"#).unwrap();
+        assert_eq!(input.string.value(), "Test string");
+        assert_eq!(input.quote_char, Some('"'));
+        assert_eq!(input.escape_char, Some('\\'));
+    }
+
+    #[test]
+    fn test_named_quote_and_escape_char() {
+        let input: MacroInput = parse_str(r#""Test string", quote_char = '"', escape_char = '\\'"#).unwrap();
+        assert_eq!(input.string.value(), "Test string");
+        assert_eq!(input.quote_char, Some('"'));
+        assert_eq!(input.escape_char, Some('\\'));
+    }
+
+    #[test]
+    fn test_named_escape_and_quote_char() {
+        let input: MacroInput = parse_str(r#""Test string", escape_char = '\\', quote_char = '"'"#).unwrap();
+        assert_eq!(input.string.value(), "Test string");
+        assert_eq!(input.quote_char, Some('"'));
+        assert_eq!(input.escape_char, Some('\\'));
+    }
+
+    #[test]
+    fn test_named_escape_char_only() {
+        let input: MacroInput = parse_str(r#""Test string", escape_char = '\\'"#).unwrap();
+        assert_eq!(input.string.value(), "Test string");
+        assert_eq!(input.quote_char, None);
+        assert_eq!(input.escape_char, Some('\\'));
+    }
+}

--- a/crates/macro/src/macro_input.rs
+++ b/crates/macro/src/macro_input.rs
@@ -1,5 +1,5 @@
-use syn::{Expr, Ident, LitStr, Token};
 use syn::parse::{Parse, ParseStream, Result};
+use syn::{Expr, Ident, LitStr, Token};
 
 /// Input for the whitespace merging macro.
 pub struct MacroInput {
@@ -49,7 +49,9 @@ impl Parse for MacroInput {
                             return Err(input.error("Expected a char literal for escape_char"));
                         }
                     }
-                    _ => return Err(input.error("Expected 'quote_char' or 'escape_char' identifier")),
+                    _ => {
+                        return Err(input.error("Expected 'quote_char' or 'escape_char' identifier"))
+                    }
                 }
             } else {
                 let expr: Expr = input.parse()?;
@@ -75,14 +77,18 @@ impl Parse for MacroInput {
             }
         }
 
-        Ok(MacroInput { string, quote_char, escape_char })
+        Ok(MacroInput {
+            string,
+            quote_char,
+            escape_char,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use syn::parse_str;
     use super::*;
+    use syn::parse_str;
 
     #[test]
     fn test_positional_quote_char() {
@@ -110,7 +116,8 @@ mod tests {
 
     #[test]
     fn test_named_quote_and_escape_char() {
-        let input: MacroInput = parse_str(r#""Test string", quote_char = '"', escape_char = '\\'"#).unwrap();
+        let input: MacroInput =
+            parse_str(r#""Test string", quote_char = '"', escape_char = '\\'"#).unwrap();
         assert_eq!(input.string.value(), "Test string");
         assert_eq!(input.quote_char, Some('"'));
         assert_eq!(input.escape_char, Some('\\'));
@@ -118,7 +125,8 @@ mod tests {
 
     #[test]
     fn test_named_escape_and_quote_char() {
-        let input: MacroInput = parse_str(r#""Test string", escape_char = '\\', quote_char = '"'"#).unwrap();
+        let input: MacroInput =
+            parse_str(r#""Test string", escape_char = '\\', quote_char = '"'"#).unwrap();
         assert_eq!(input.string.value(), "Test string");
         assert_eq!(input.quote_char, Some('"'));
         assert_eq!(input.escape_char, Some('\\'));

--- a/crates/macro/src/macro_input.rs
+++ b/crates/macro/src/macro_input.rs
@@ -139,4 +139,87 @@ mod tests {
         assert_eq!(input.quote_char, None);
         assert_eq!(input.escape_char, Some('\\'));
     }
+
+    #[test]
+    fn test_invalid_input() {
+        // Invalid inputs with named arguments
+        assert!(
+            parse_str::<MacroInput>(r#""Test string", quote_char = var, escape_char = '\\'"#)
+                .is_err()
+        );
+        assert!(parse_str::<MacroInput>(
+            r#""Test string", quote_char = foo[0], escape_char = '\\'"#
+        )
+        .is_err());
+        assert!(parse_str::<MacroInput>(
+            r#""Test string", quote_char = "car", escape_char = '\\'"#
+        )
+        .is_err());
+        assert!(
+            parse_str::<MacroInput>(r#""Test string", quote_char = 12, escape_char = '\\'"#)
+                .is_err()
+        );
+        assert!(
+            parse_str::<MacroInput>(r#""Test string", quote_char = #, escape_char = '\\'"#)
+                .is_err()
+        );
+        assert!(
+            parse_str::<MacroInput>(r#""Test string", quote_char = '"', escape_char = var"#)
+                .is_err()
+        );
+        assert!(parse_str::<MacroInput>(
+            r#""Test string", quote_char = '"', escape_char = foo[0]"#
+        )
+        .is_err());
+        assert!(parse_str::<MacroInput>(
+            r#""Test string", quote_char = '"', escape_char = "quote""#
+        )
+        .is_err());
+        assert!(
+            parse_str::<MacroInput>(r#""Test string", quote_char = '"', escape_char = 12"#)
+                .is_err()
+        );
+
+        // Invalid inputs with positional arguments
+        assert!(parse_str::<MacroInput>(r#""Test string", "car", '\\'"#).is_err());
+        assert!(parse_str::<MacroInput>(r#""Test string", 12, '\\'"#).is_err());
+        assert!(parse_str::<MacroInput>(r#""Test string", #, '\\'"#).is_err());
+        assert!(parse_str::<MacroInput>(r#""Test string", var, '\\'"#).is_err());
+        assert!(parse_str::<MacroInput>(r#""Test string", foo[0], '\\'"#).is_err());
+        assert!(parse_str::<MacroInput>(r#""Test string", a = b, '\\'"#).is_err());
+        assert!(parse_str::<MacroInput>(r#""Test string", '"', "quote""#).is_err());
+        assert!(parse_str::<MacroInput>(r#""Test string", '"', 12"#).is_err());
+        assert!(parse_str::<MacroInput>(r#""Test string", '"', var"#).is_err());
+        assert!(parse_str::<MacroInput>(r#""Test string", '"', foo[0]"#).is_err());
+        assert!(parse_str::<MacroInput>(r#""Test string", '"', a = b"#).is_err());
+        assert!(parse_str::<MacroInput>(r#""Test string", foo = bar, a = b"#).is_err());
+        assert!(parse_str::<MacroInput>(r#""Test string", "failure"#).is_err());
+
+        // Missing comma
+        assert!(
+            parse_str::<MacroInput>(r#""Test string", quote_char = '"' escape_char = '\\'"#)
+                .is_err()
+        );
+        assert!(
+            parse_str::<MacroInput>(r#""Test string" quote_char = '"', escape_char = '\\'"#)
+                .is_err()
+        );
+
+        // Invalid argument
+        assert!(
+            parse_str::<MacroInput>(r#""Test string", quote_chars = '"', escape_char = '\\'"#)
+                .is_err()
+        );
+        assert!(
+            parse_str::<MacroInput>(r#""Test string", quote_char = '"', escape_chars = '\\'"#)
+                .is_err()
+        );
+
+        // Too many arguments
+        assert!(parse_str::<MacroInput>(r#""Test string", '"', '\\', 42"#).is_err());
+        assert!(parse_str::<MacroInput>(
+            r#""Test string", quote_char = '"', escape_char = '\\', invalid = true"#
+        )
+        .is_err());
+    }
 }


### PR DESCRIPTION
This now allows for embedded quotation marks to be kept, and for escaping to keep some text as-is:

```rust
use merge_whitespace::merge_whitespace;

const QUERY: &str = merge_whitespace!(r#"
     query {
       users (limit: 1, filter: "bought a 12\" vinyl
                                 named \"spaces  in  space \"") {
         id
         name
         todos(order_by: {created_at: desc}, limit: 5) {
           id
           title
         }
       }
     }
     "#,
     quote_char = '"',
     escape_char = '\\');

#[test]
fn test() {
    assert_eq!(QUERY, r#"query { users (limit: 1, filter: "bought a 12\" vinyl
                                 named \"spaces  in  space \"") { id name todos(order_by: {created_at: desc}, limit: 5) { id title } } }"#);
}
```

![image](https://github.com/sunsided/merge-whitespace-rs/assets/495335/eba04d4d-8184-48af-826f-36316e498cbd)

